### PR TITLE
Configure UT to read JSPF files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ module.exports.init = function() {
                     return item.trim();
                 }
             );
-        }, ['js', 'jsp', 'css'])
+        }, ['js', 'jsp', 'jspf', 'css'])
         .version('0.0.1')
         .parse(process.argv);
 
@@ -84,6 +84,10 @@ module.exports.init = function() {
     function processFile(fileName, extension) {
         var context,
             processors;
+
+        if (extension === 'jspf') {
+            extension = 'jsp';
+        }
 
         context = getContext(extension);
         processors = PROCESSORS[extension];


### PR DESCRIPTION
Hey @ipeychev, there might be a better way of doing this. But this fix is for an issue I just made. I noticed that the UT ignores all JSPF files. In this fix it just uses all the same code that it would for a JSP.
